### PR TITLE
docs(lab1): RecordIDTest should be RecordIdTest

### DIFF
--- a/lab1.md
+++ b/lab1.md
@@ -402,7 +402,7 @@ Although you will not use them directly in Lab 1, we ask you to implement <tt>ge
 
 You will also need to implement an Iterator over the tuples in the page, which may involve an auxiliary class or data structure.  
 
-At this point, your code should pass the unit tests in HeapPageIdTest, RecordIDTest, and HeapPageReadTest.
+At this point, your code should pass the unit tests in HeapPageIdTest, RecordIdTest, and HeapPageReadTest.
 
 
 <p> 


### PR DESCRIPTION
When someone run 

```bash
# test name copy from doc
ant runtest -Dtest=RecordIDTest
```

will cause a error

```java
    [junit]     Caused an ERROR
    [junit] simpledb/RecordIDTest (wrong name: simpledb/RecordIdTest)
    [junit] java.lang.NoClassDefFoundError: simpledb/RecordIDTest (wrong name: simpledb/RecordIdTest)
```

The command should be
```bash
ant runtest -Dtest=RecordIdTest
```

`d` in `RecordIDTest` should be lowercase